### PR TITLE
Update ps-rule action version to v2.9.0

### DIFF
--- a/bicep-lint-code/action.yml
+++ b/bicep-lint-code/action.yml
@@ -50,7 +50,7 @@ runs:
         }
 
     - name: Analyze Azure template files
-      uses: Microsoft/ps-rule@main
+      uses: Microsoft/ps-rule@v2.9.0
       with:
         outputFormat: NUnit3
         outputPath: reports/ps-rule-results.xml


### PR DESCRIPTION
You are not pinned to a version and this is likely to break as development of v3 progresses.

See: https://github.com/microsoft/ps-rule?tab=readme-ov-file#usage