### PR TITLE
Wire frasermolyneux-copilot MCP server (pinned v0.1.0)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,3 +11,9 @@
 - Documentation: see [docs/action-versioning.md](docs/action-versioning.md) for tag shapes, [docs/codequality.md](docs/codequality.md) for the reusable workflow inputs, and [docs/nerdbank-gitversioning.md](docs/nerdbank-gitversioning.md) for NBGV expectations.
 
 If anything here feels incomplete or unclear, let me know so we can tighten these notes.
+
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,4 +32,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: frasermolyneux/.github-copilot
+          ref: refs/tags/v0.1.0
           path: .github-copilot
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+
+      - name: Build MCP server
+        run: npm ci && npm run build
+        working-directory: .github-copilot/mcp-server

--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 
 ## Security
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
+
+## Local dev: MCP wire-up
+This repo is wired to load the shared `frasermolyneux-copilot` MCP server when running under Copilot CLI or the GitHub Copilot coding agent. The wire-up lives in `.github/workflows/copilot-setup-steps.yml` (checks out `frasermolyneux/.github-copilot` at tag `v0.1.0` and builds the MCP server) and `.github/copilot/mcp_config.json` (spawn config). For the full tool surface, content-root resolution, and per-client wire-up snippets, see `.github-copilot/mcp-server/README.md` in [`frasermolyneux/.github-copilot`](https://github.com/frasermolyneux/.github-copilot).


### PR DESCRIPTION
Wires this repo into the shared `frasermolyneux-copilot` MCP server so the GitHub Copilot coding agent (and any other MCP-capable client) can query org conventions live instead of relying on file snapshots. Matches the template already merged into `portal-core` and pins to tag `v0.1.0` on `frasermolyneux/.github-copilot` so the wire-up is reproducible.

## Changes

- **`.github/workflows/copilot-setup-steps.yml`** - pin the existing `frasermolyneux/.github-copilot` checkout to `ref: refs/tags/v0.1.0`, add `actions/setup-node@v6` (Node 20.x), and add a `Build MCP server` step (`npm ci && npm run build` in `.github-copilot/mcp-server`) so the agent's runtime has the built `dist/index.js` ready to spawn.
- **`.github/copilot/mcp_config.json`** - new file declaring the local `frasermolyneux-copilot` MCP server (spawns `node .github-copilot/mcp-server/dist/index.js` with `GH_COPILOT_CONTENT_ROOT=.github-copilot`).
- **`.github/copilot-instructions.md`** - append the canonical "Org conventions via MCP (when available)" bootstrap section (sourced byte-for-byte from `metadata.copilot-instructions` in `frasermolyneux/.github-copilot`).
- **`README.md`** - add a brief `## Local dev: MCP wire-up` pointer to `.github-copilot/mcp-server/README.md` for full docs.

## Notes for reviewers

- `AGENTS.md` is intentionally not added here. This repo doesn't have one yet, and the canonical body is owned by the `update-project-metadata` agent; adding the MCP snippet alone (without the rest of the file) would drift from the rollout pattern. Worth a follow-up.
- `tools: ["*"]` matches the orchestrator spec exactly; `portal-core` uses an explicit allowlist. Functionally equivalent today; flag if alignment with the allowlist form is preferred.
- The canonical snippet is conditional by design - it reads as a no-op for clients without an MCP server configured, and activates cleanly once one is.